### PR TITLE
Expose entire secret contents in `.full`

### DIFF
--- a/pass/data_source_password.go
+++ b/pass/data_source_password.go
@@ -37,6 +37,12 @@ func passwordDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "raw secret data if not YAML.",
 			},
+
+			"full": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "entire secret contents",
+			},
 		},
 	}
 }
@@ -64,6 +70,10 @@ func passwordDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("body", sec.Body()); err != nil {
 		log.Printf("[ERROR] Error when setting body: %v", err)
+		return err
+	}
+	if err := d.Set("full", sec.String()); err != nil {
+		log.Printf("[ERROR] Error when setting full: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
These changes would allow the entire secret contents to be retrieved from a data source in the `.string` attribute, as suggested in https://github.com/camptocamp/terraform-provider-pass/issues/8.

Although "string" is a very fluffy term, I went with what gopass is already using: [`Secret.String()`](https://github.com/justwatchcom/gopass/blob/master/pkg/store/secret/secret.go#L66).

Any thoughts?