### PR TITLE
Add improvements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Pass Terraform Provider
 =======================
+This provider adds integration between Terraform and [Pass][] and [Gopass][] password stores.
 
-[Pass](https://www.passwordstore.org/) is a password store using gpg to encrypt password and git to version.
-[Gopass](https://www.justwatch.com/gopass/) is a rewrite of the pass password manager in Go with the aim of making it cross-platform and adding additional features.
+[Pass][] is a password store using gpg to encrypt password and git to version.
+[Gopass][] is a rewrite of the pass password manager in Go with the aim of making it cross-platform and adding additional features.
 
 Requirements
 ------------
@@ -26,6 +27,11 @@ $ cd $GOPATH/src/github.com/camptocamp/terraform-provider-pass
 $ dep ensure
 $ make build
 ```
+
+Installing the provider
+-----------------------
+
+After building the provider, install it using the Terraform instructions for [installing a third party provider](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins).
 
 Using the provider
 ----------------------
@@ -78,3 +84,7 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+
+[Pass]: https://www.passwordstore.org/
+[Gopass]: https://www.justwatch.com/gopass/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Installing the provider
 
 After building the provider, install it using the Terraform instructions for [installing a third party provider](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins).
 
-Using the provider
+Example
 ----------------------
 
 ```hcl
@@ -56,6 +56,46 @@ data "pass_password" "test" {
 }
 ```
 
+Usage
+----------------------
+
+### The `pass` provider
+#### Argument Reference
+The provider takes the following arguments:
+- `store_dir` - (Optional) Path to your password store, defaults to `$PASSWORD_STORE_DIR`
+- `refresh_store` - (Optional) Boolean whether to call `git pull` when configuring the provider, defaults to `true`
+
+
+### The `pass_password` resource
+#### Argument Reference
+The resource takes the following arguments:
+- `path` - Full path from which a password will be read
+- `password` - Secret password
+- `data` - (Optional) Additional secret data
+
+#### Attribute Reference
+The following attributes are exported:
+
+- `path` - Full path from which the password was read
+- `password` - Secret password
+- `data` - Additional secret data
+- `body` - Raw secret data if not YAML
+- `full` - Entire secret contents
+
+
+### The `pass_password` data source
+#### Argument Reference
+The data source takes the following arguments:
+ - `path` - Full path from which a password will be read
+
+#### Attribute Reference
+The following attributes are exported:
+
+- `path` - Full path from which the password was read
+- `password` - Secret password
+- `data` - Additional secret data
+- `body` - Raw secret data if not YAML
+- `full` - Entire secret contents
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
- Clarify purpose and terraform plugin installation
- Add usage documentation to follow Terraform docs style

Let me know if you think this is useful. The usage documentation might be a bit overkill/repetitive so do let me know if you think I should try and trim it down to a shorter length. 