### PR TITLE
Actually return an error if the store is not initialized

### DIFF
--- a/pass/provider.go
+++ b/pass/provider.go
@@ -53,7 +53,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	if !act.Store.Initialized(ctx) {
-		return nil, errors.Wrap(err, "password-store not initialized")
+		return nil, errors.New("password-store not initialized")
 	}
 	st := act.Store
 


### PR DESCRIPTION
`err` in this case refers to a previous error which is always nil.  If
you call errors.Wrap() on a nil value, you get a nil value.

----

Fuller explanation: before this commit, you could have terraform
crashes if you set a store_dir to a bad value.  Here's a minimal
reproduction:

    provider "pass" {
      store_dir = "/non/existent/"
    }

    data "pass_password" "foo" {
      path = "bar"
    }

If you try to run this terraform code, you get a panic.  The problem
is that the ConfigureFunc returned (nil, nil) where it should have
returned an error.

The fix is to call errors.New() instead of errors.Wrap().