### PR TITLE
Update README.md with go v1.10 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.9 and [dep](https://golang.github.io/dep/) (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.10 and [dep](https://golang.github.io/dep/) (to build the provider plugin)
 
 Building The Provider
 ---------------------


### PR DESCRIPTION
Because of the [go v1.10 requirement](https://github.com/gopasspw/gopass#installation) of gopass, this project cannot be built with go v1.9 anymore.

This is obvious when trying to build with v1.9:

```
$ go build
# github.com/camptocamp/terraform-provider-pass/vendor/github.com/gopasspw/gopass/pkg/store/secret
vendor/github.com/gopasspw/gopass/pkg/store/secret/kv.go:64:10: undefined: strings.Builder
vendor/github.com/gopasspw/gopass/pkg/store/secret/secret.go:67:10: undefined: strings.Builder

...
```

This is fixed by upgrading to 1.10.4 (current latest of 1.10).