### PR TITLE
Compile provider with static binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 default: build
 
 build: fmtcheck
-	go install
+	CGO_ENABLED=0 go install
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,6 +4,9 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 default: build
 
 build: fmtcheck
+	go install
+
+static-build: fmtcheck
 	CGO_ENABLED=0 go install
 
 test: fmtcheck
@@ -43,5 +46,5 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile
+.PHONY: build static-build test testacc vet fmt fmtcheck errcheck vendor-status test-compile
 


### PR DESCRIPTION
Same as https://github.com/terraform-providers/terraform-provider-helm/pull/111: By default Go will compile dynamic binaries if possible. When compiling from linux this means that Go will produce a dynamically linked binary, which can be problematic for running on alpine images (musl-based). This PR is meant to fix this by setting CGO_ENABLED=0 when compiling.