### PR TITLE
Update README.md with terraform v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This provider adds integration between Terraform and [Pass][] and [Gopass][] pas
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
+-	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -	[Go](https://golang.org/doc/install) 1.10 and [dep](https://golang.github.io/dep/) (to build the provider plugin)
 
 Building The Provider


### PR DESCRIPTION
This has been a little confusing, since the latest release is meant to be used in combination with terraform v0.12.0.