### PR TITLE
set password resources values as sensitive

### DIFF
--- a/pass/resource_pass_password.go
+++ b/pass/resource_pass_password.go
@@ -32,12 +32,14 @@ func passPasswordResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "secret password.",
+				Sensitive: true,
 			},
 
 			"data": &schema.Schema{
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Description: "additional secret data.",
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
This will stop values of password resources from being displayed in plan creation and applying