### PR TITLE
chore: fix darwin make command for arm macs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ windows: fmtcheck
 darwin: fmtcheck
 	@mkdir -p bin/
 	GOOS=darwin GOARCH=amd64 go build -v -o bin/$(BINARY)_$(VERSION)_darwin_amd64
-	GOOS=darwin GOARCH=386 go build -v -o bin/$(BINARY)_$(VERSION)_darwin_x86
+	GOOS=darwin GOARCH=arm64 go build -v -o bin/$(BINARY)_$(VERSION)_darwin_x86
 
 release: clean linux windows darwin
 	for f in $(shell ls bin/); do zip bin/$${f}.zip bin/$${f}; done


### PR DESCRIPTION
## Summary

This PR fixes make target for Darwin, else using the existing `make darwin` command results in the following error : 

```
make darwin
==> Checking that code complies with gofmt requirements...
GOOS=darwin GOARCH=amd64 go build -v -o bin/terraform-provider-pass_v2.0.0-7-g6fc37c1f_darwin_amd64
github.com/camptocamp/terraform-provider-pass/pass
github.com/camptocamp/terraform-provider-pass
GOOS=darwin GOARCH=386 go build -v -o bin/terraform-provider-pass_v2.0.0-7-g6fc37c1f_darwin_x86
go: unsupported GOOS/GOARCH pair darwin/386
make: *** [darwin] Error 2
```

After this fix `make darwin` succeeds

```
make darwin
==> Checking that code complies with gofmt requirements...
GOOS=darwin GOARCH=amd64 go build -v -o bin/terraform-provider-pass_v2.0.0-7-g6fc37c1f_darwin_amd64
GOOS=darwin GOARCH=arm64 go build -v -o bin/terraform-provider-pass_v2.0.0-7-g6fc37c1f_darwin_x86
github.com/camptocamp/terraform-provider-pass/pass
github.com/camptocamp/terraform-provider-pass
```